### PR TITLE
en-passant fix

### DIFF
--- a/chess_validator.h
+++ b/chess_validator.h
@@ -238,22 +238,24 @@ bool            get_table_state( const char* fen_string , TableState* ptr_table_
 
     // Fourth field: EN passant field
     int en_passant_square = 0;
-    switch (fen_string[string_iterator++]){
-        case '-': break;
-        case 'h': en_passant_square += 7; break;
-        case 'g': en_passant_square += 6; break;
-        case 'f': en_passant_square += 5; break;
-        case 'e': en_passant_square += 4; break;
-        case 'd': en_passant_square += 3; break;
-        case 'c': en_passant_square += 2; break;
-        case 'b': en_passant_square += 1; break;
-        case 'a': en_passant_square += 0; break;
-        default:
-            switch( fen_string[string_iterator++] ){
-                case '3': en_passant_square += 40; break;
-                case '6': en_passant_square += 16; break;
-                default: return false;
-            }
+    for (int i = 0; i < 2; i ++ ) {
+        switch (fen_string[string_iterator++]){
+            case '-': i = 3; break;
+            case 'h': en_passant_square += 7; break;
+            case 'g': en_passant_square += 6; break;
+            case 'f': en_passant_square += 5; break;
+            case 'e': en_passant_square += 4; break;
+            case 'd': en_passant_square += 3; break;
+            case 'c': en_passant_square += 2; break;
+            case 'b': en_passant_square += 1; break;
+            case 'a': en_passant_square += 0; break;
+            default:
+                switch( fen_string[string_iterator++] ){
+                    case '3': en_passant_square += 40; break;
+                    case '6': en_passant_square += 16; break;
+                    default: return false;
+                }
+        } 
     }
     if( en_passant_square != 0 )    table_state.en_passant_index = en_passant_square;
     else                            table_state.en_passant_index = -1;

--- a/chess_validator.h
+++ b/chess_validator.h
@@ -663,8 +663,9 @@ INVALID_REASON  is_move_invalid( TableState* ptr_table_state , int source_index 
             if( abs(delta_index)!=9 && abs(delta_index)!=7 )
                 return INVALID_UNIT_MOVE;
             } else {
-                if( abs(delta_x) > 0 || abs(delta_y) > 2 ) return INVALID_UNIT_MOVE;
-                if( first_move ){                
+                if( abs(delta_x) > 0 ) return INVALID_UNIT_MOVE;
+                if( first_move ){
+                    if( abs(delta_y) > 2 ) return INVALID_UNIT_MOVE;
                     if( abs(delta_y) == 2 ){
                         if( table_state.map[source_index+delta_index/2] ) 
                             return INVALID_UNIT_MOVE; // Can't jump over units

--- a/chess_validator.h
+++ b/chess_validator.h
@@ -718,8 +718,18 @@ INVALID_REASON  is_move_invalid( TableState* ptr_table_state , int source_index 
         bool white_queen_castling = table_state.white_queen_castling && (source_square&COLOR_WHITE) && (table_state.map[56]&COLOR_WHITE) && (table_state.map[56]&TYPE_ROOK) && source_index == 60 && target_index == 58 && (table_state.map[57]==0) && (table_state.map[58]==0) && (table_state.map[59]==0) ;
         
         bool any_castling = ( black_king_castling || black_queen_castling || white_king_castling || white_queen_castling );
+
         if( !any_castling && ( abs(delta_x)>1 || abs(delta_y)>1 ) ) 
             return INVALID_UNIT_MOVE;
+
+        if( any_castling ) {
+            // king in check during castling ?
+            int half_target_index = target_index > source_index ? source_index + 1 : source_index - 1;
+            int opponent_king_color = ptr_table_state->next_color_to_play;
+            TableState castling_inbetween_state = apply_move( ptr_table_state , source_index , half_target_index , TYPE_QUEEN );
+            bool king_in_check_at_castling = is_king_in_check(&castling_inbetween_state,opponent_king_color);
+            if( king_in_check_at_castling ) return KING_IN_CHECK;
+        }
     } 
 
     int current_player_color = ptr_table_state->next_color_to_play;

--- a/chess_validator.h
+++ b/chess_validator.h
@@ -721,15 +721,14 @@ INVALID_REASON  is_move_invalid( TableState* ptr_table_state , int source_index 
 
         if( !any_castling && ( abs(delta_x)>1 || abs(delta_y)>1 ) ) 
             return INVALID_UNIT_MOVE;
-
         if( any_castling ) {
+            // king in check before castling ?
+            if( is_king_in_check(ptr_table_state,ptr_table_state->next_color_to_play) ) return INVALID_UNIT_MOVE;
             // king in check during castling ?
-            int half_target_index = target_index > source_index ? source_index + 1 : source_index - 1;
-            int opponent_king_color = ptr_table_state->next_color_to_play;
-            TableState castling_inbetween_state = apply_move( ptr_table_state , source_index , half_target_index , TYPE_QUEEN );
-            bool king_in_check_at_castling = is_king_in_check(&castling_inbetween_state,opponent_king_color);
-            if( king_in_check_at_castling ) return KING_IN_CHECK;
-        }
+            int half_target_index = target_index > source_index ? source_index + 1 : source_index - 1;            
+            TableState castling_inbetween_state = apply_move( ptr_table_state , source_index , half_target_index , TYPE_QUEEN );                        
+            if( is_king_in_check(&castling_inbetween_state,ptr_table_state->next_color_to_play) ) return INVALID_UNIT_MOVE;
+        }  
     } 
 
     int current_player_color = ptr_table_state->next_color_to_play;

--- a/chess_validator.h
+++ b/chess_validator.h
@@ -662,16 +662,15 @@ INVALID_REASON  is_move_invalid( TableState* ptr_table_state , int source_index 
         if( capturing ){
             if( abs(delta_index)!=9 && abs(delta_index)!=7 )
                 return INVALID_UNIT_MOVE;
-        } else {
-            if( abs(delta_x) > 0 ) return INVALID_UNIT_MOVE;
-            if( first_move ){
-                if( abs(delta_y) > 2 ) return INVALID_UNIT_MOVE;
-                if( abs(delta_y) == 2 ){
-                    if( table_state.map[source_index+delta_index/2] ) 
-                        return INVALID_UNIT_MOVE; // Can't jump over units
-                }
+            } else {
+                if( abs(delta_x) > 0 || abs(delta_y) > 2 ) return INVALID_UNIT_MOVE;
+                if( first_move ){                
+                    if( abs(delta_y) == 2 ){
+                        if( table_state.map[source_index+delta_index/2] ) 
+                            return INVALID_UNIT_MOVE; // Can't jump over units
+                    }
+                } else if( abs(delta_y) > 1 ) return INVALID_UNIT_MOVE;
             }
-        }
     } 
     else if ( source_square & SQUARE::TYPE_KNIGHT ){
         if( abs(delta_x) + abs(delta_y) != 3 ) return INVALID_UNIT_MOVE;


### PR DESCRIPTION
The default - case is not reached for a 2 - chars long en-passant fields. So, after first character (if not '-') we have to repeat the check.